### PR TITLE
fix: fix typo on get table rows variables

### DIFF
--- a/src/pages/delegator/index.tsx
+++ b/src/pages/delegator/index.tsx
@@ -52,7 +52,7 @@ const Delegator: NextPage = () => {
       scope: walletConfig.rewardAccount,
       table: 'voter',
       lower_bound: state.ual.accountName,
-      uppper_bound: state.ual.accountName,
+      upper_bound: state.ual.accountName,
       json: true,
       limit: 1
     })

--- a/src/utils/eosio.ts
+++ b/src/utils/eosio.ts
@@ -13,7 +13,7 @@ const getMemberVotes = async <T = any>(account: string): Promise<T> => {
     scope: sdkConfig.eosioContract,
     table: 'voters',
     lower_bound: account,
-    uppper_bound: account,
+    upper_bound: account,
     json: true,
     limit: 1
   })


### PR DESCRIPTION
### Typo on get table rows variables

### What does this PR do?

- Resolve #265 

### Steps to test

1. first step
2. next step

#### CheckList

- [] Follow proper Markdown format
- [] The content is adequate
- [] The content is available in both english and spanish
- [] I Ran a spell check
