### PR TITLE
refacctor(general): use eos instead of eden prefix

### DIFF
--- a/contracts/proxyfund/include/constants.hpp
+++ b/contracts/proxyfund/include/constants.hpp
@@ -5,7 +5,7 @@
 
 namespace fund {
   inline constexpr auto token_contract = "eosio.token"_n;
-  inline constexpr auto reward_contract = "edenproxyrwd"_n;
+  inline constexpr auto reward_contract = "eosproxyrwds"_n;
   inline constexpr auto default_token_symbol = eosio::symbol( "EOS", 4 );
 
 } // namespace fund

--- a/contracts/proxyfund/include/fund.hpp
+++ b/contracts/proxyfund/include/fund.hpp
@@ -21,6 +21,6 @@ namespace fund {
                           std::string         memo );
   };
 
-  EOSIO_ACTIONS( funds, "edenprxfunds"_n, notify( token_contract, transfer ) )
+  EOSIO_ACTIONS( funds, "eosproxyfund"_n, notify( token_contract, transfer ) )
 
 } // namespace fund

--- a/contracts/proxyfund/tests/include/tester-base.hpp
+++ b/contracts/proxyfund/tests/include/tester-base.hpp
@@ -12,13 +12,13 @@ using namespace eosio;
 using user_context = test_chain::user_context;
 
 void proxyfunds_setup( test_chain &t ) {
-  t.set_code( "edenprxfunds"_n, "edenprxfunds.wasm" );
+  t.set_code( "eosproxyfund"_n, "eosproxyfund.wasm" );
 }
 
 struct tester {
   test_chain   chain;
   user_context eden = chain.as( "genesis.eden"_n );
-  user_context edenproxyrwd = chain.as( "edenprxfunds"_n );
+  user_context eosproxyrwds = chain.as( "eosproxyfund"_n );
 
   user_context alice = chain.as( "alice"_n );
   user_context bob = chain.as( "bob"_n );

--- a/contracts/proxyreward/include/constants.hpp
+++ b/contracts/proxyreward/include/constants.hpp
@@ -7,5 +7,5 @@ namespace edenproxy {
   inline constexpr auto PROXY_CONTRACT = "edensmartprx"_n;
   inline constexpr auto SUPPORTED_TOKEN_CONTRACT = "eosio.token"_n;
   inline constexpr auto SUPPORTED_TOKEN_SYMBOL = eosio::symbol( "EOS", 4 );
-  inline constexpr auto DEFAULT_FUNDING_CONTRACT = "edenprxfunds"_n;
+  inline constexpr auto DEFAULT_FUNDING_CONTRACT = "eosproxyfund"_n;
 } // namespace edenproxy

--- a/contracts/proxyreward/include/reward.hpp
+++ b/contracts/proxyreward/include/reward.hpp
@@ -38,7 +38,7 @@ namespace edenproxy {
 
   EOSIO_ACTIONS(
       reward,
-      "edenproxyrwd"_n,
+      "eosproxyrwds"_n,
       action( init ),
       action( signup, owner, recipient ),
       action( resign, owner ),

--- a/contracts/proxyreward/tests/include/tester-base.hpp
+++ b/contracts/proxyreward/tests/include/tester-base.hpp
@@ -18,13 +18,13 @@ using namespace eosio;
 using user_context = test_chain::user_context;
 
 void proxyreward_setup( test_chain &t ) {
-  t.create_code_account( "edenproxyrwd"_n );
-  t.set_code( "edenproxyrwd"_n, "proxyreward.wasm" );
+  t.create_code_account( "eosproxyrwds"_n );
+  t.set_code( "eosproxyrwds"_n, "proxyreward.wasm" );
 }
 
 void proxyfunds_setup( test_chain &t ) {
-  t.create_code_account( "edenprxfunds"_n );
-  t.set_code( "edenprxfunds"_n, "fund.wasm" );
+  t.create_code_account( "eosproxyfund"_n );
+  t.set_code( "eosproxyfund"_n, "fund.wasm" );
 }
 
 void token_setup( test_chain &t ) {
@@ -65,8 +65,8 @@ struct tester {
   user_context token = chain.as( "eosio.token"_n );
   user_context faketoken = chain.as( "fake.token"_n );
   user_context eden = chain.as( "genesis.eden"_n );
-  user_context edenprxfunds = chain.as( "edenprxfunds"_n );
-  user_context edenproxyrwd = chain.as( "edenproxyrwd"_n );
+  user_context eosproxyfund = chain.as( "eosproxyfund"_n );
+  user_context eosproxyrwds = chain.as( "eosproxyrwds"_n );
 
   user_context alice = chain.as( "alice"_n );
   user_context bob = chain.as( "bob"_n );
@@ -140,11 +140,11 @@ struct tester {
   }
 
   auto get_account() const {
-    return edenproxy::accounts( "edenproxyrwd"_n ).account();
+    return edenproxy::accounts( "eosproxyrwds"_n ).account();
   };
 
   auto get_distribution() const {
-    return edenproxy::distributions( "edenproxyrwd"_n ).distribution();
+    return edenproxy::distributions( "eosproxyrwds"_n ).distribution();
   };
 
   void full_signup() {
@@ -158,8 +158,8 @@ struct tester {
 
   auto get_voters() const {
     std::map< eosio::name, std::vector< uint64_t > > result;
-    edenproxy::voter_table_type                      voter_tb{ "edenproxyrwd"_n,
-                                          "edenproxyrwd"_n.value };
+    edenproxy::voter_table_type                      voter_tb{ "eosproxyrwds"_n,
+                                          "eosproxyrwds"_n.value };
 
     for ( auto t : voter_tb ) {
       if ( auto *voter = std::get_if< edenproxy::voter_v1 >( &t.value ) ) {
@@ -174,8 +174,8 @@ struct tester {
 
   auto get_recipients() const {
     std::map< eosio::name, eosio::name > result;
-    edenproxy::voter_table_type          voter_tb{ "edenproxyrwd"_n,
-                                          "edenproxyrwd"_n.value };
+    edenproxy::voter_table_type          voter_tb{ "eosproxyrwds"_n,
+                                          "eosproxyrwds"_n.value };
 
     for ( auto t : voter_tb ) {
       if ( auto *voter = std::get_if< edenproxy::voter_v1 >( &t.value ) ) {

--- a/contracts/proxyreward/tests/tests-proxyreward.cpp
+++ b/contracts/proxyreward/tests/tests-proxyreward.cpp
@@ -12,10 +12,10 @@ TEST_CASE( "Init Smart Contract" ) {
   expect( t.alice.trace< edenproxy::actions::init >(),
           "Missing required authority" );
 
-  t.edenproxyrwd.act< edenproxy::actions::init >();
+  t.eosproxyrwds.act< edenproxy::actions::init >();
   t.chain.start_block();
 
-  expect( t.edenproxyrwd.trace< edenproxy::actions::init >(),
+  expect( t.eosproxyrwds.trace< edenproxy::actions::init >(),
           "Contract is already initialized" );
 
   CHECK( t.get_account().balance == s2a( "0.0000 EOS" ) );
@@ -29,9 +29,9 @@ TEST_CASE( "Sign up and remove" ) {
 
   t.fund_accounts();
 
-  t.edenproxyrwd.act< edenproxy::actions::init >();
+  t.eosproxyrwds.act< edenproxy::actions::init >();
   t.alice.act< token::actions::transfer >( "alice"_n,
-                                           "edenprxfunds"_n,
+                                           "eosproxyfund"_n,
                                            s2a( "500.0000 EOS" ),
                                            "donation" );
 
@@ -115,7 +115,7 @@ TEST_CASE( "Send tokens from fake contract and symbol" ) {
 
   t.fund_accounts();
 
-  t.edenproxyrwd.act< edenproxy::actions::init >();
+  t.eosproxyrwds.act< edenproxy::actions::init >();
   t.alice.with_code( "fake.token"_n )
       .act< token::actions::transfer >( "alice"_n,
                                         edenproxy::DEFAULT_FUNDING_CONTRACT,
@@ -123,11 +123,11 @@ TEST_CASE( "Send tokens from fake contract and symbol" ) {
                                         "donation" );
   t.alice.with_code( "fake.token"_n )
       .act< token::actions::transfer >( "alice"_n,
-                                        "edenproxyrwd"_n,
+                                        "eosproxyrwds"_n,
                                         s2a( "500.0000 EOS" ),
                                         "donation" );
   t.alice.act< token::actions::transfer >( "alice"_n,
-                                           "edenproxyrwd"_n,
+                                           "eosproxyrwds"_n,
                                            s2a( "500.0000 OTHER" ),
                                            "donation" );
 
@@ -150,12 +150,12 @@ TEST_CASE( "Send tokens from fake contract and symbol" ) {
                                         s2a( "500.0000 EOS" ),
                                         "donation" );
   t.alice.act< token::actions::transfer >( "alice"_n,
-                                           "edenproxyrwd"_n,
+                                           "eosproxyrwds"_n,
                                            s2a( "500.0000 EOS" ),
                                            "donation" );
   t.chain.as( "eosio"_n )
       .act< token::actions::transfer >( "eosio"_n,
-                                        "edenproxyrwd"_n,
+                                        "eosproxyrwds"_n,
                                         s2a( "500.0000 EOS" ),
                                         "donation" );
 
@@ -167,16 +167,16 @@ TEST_CASE( "Receive the inflation amount" ) {
 
   t.fund_accounts();
 
-  t.edenproxyrwd.act< edenproxy::actions::init >();
+  t.eosproxyrwds.act< edenproxy::actions::init >();
   t.alice.act< token::actions::transfer >( "alice"_n,
-                                           "edenprxfunds"_n,
+                                           "eosproxyfund"_n,
                                            s2a( "500.0000 EOS" ),
                                            "donation" );
 
   CHECK( t.get_account().balance == s2a( "500.0000 EOS" ) );
 
   t.alice.act< token::actions::transfer >( "alice"_n,
-                                           "edenprxfunds"_n,
+                                           "eosproxyfund"_n,
                                            s2a( "12.0000 EOS" ),
                                            "donation" );
 
@@ -189,9 +189,9 @@ TEST_CASE( "Distribute" ) {
   t.fund_accounts();
   t.skip_to( "2023-01-01T07:00:00.000" );
 
-  t.edenproxyrwd.act< edenproxy::actions::init >();
+  t.eosproxyrwds.act< edenproxy::actions::init >();
   t.alice.act< token::actions::transfer >( "alice"_n,
-                                           "edenprxfunds"_n,
+                                           "eosproxyfund"_n,
                                            s2a( "512.0000 EOS" ),
                                            "donation" );
 
@@ -234,7 +234,7 @@ TEST_CASE( "Distribute" ) {
   CHECK( t.get_voters() == expected );
 
   t.alice.act< token::actions::transfer >( "alice"_n,
-                                           "edenprxfunds"_n,
+                                           "eosproxyfund"_n,
                                            s2a( "600.0000 EOS" ),
                                            "donation" );
 
@@ -265,9 +265,9 @@ TEST_CASE( "Slow distribution" ) {
   t.fund_accounts();
   t.skip_to( "2023-01-01T07:00:00.000" );
 
-  t.edenproxyrwd.act< edenproxy::actions::init >();
+  t.eosproxyrwds.act< edenproxy::actions::init >();
   t.alice.act< token::actions::transfer >( "alice"_n,
-                                           "edenprxfunds"_n,
+                                           "eosproxyfund"_n,
                                            s2a( "512.0000 EOS" ),
                                            "donation" );
 
@@ -317,9 +317,9 @@ TEST_CASE( "Cannot resign with pending funds to claim" ) {
   t.fund_accounts();
   t.skip_to( "2023-01-01T07:00:00.000" );
 
-  t.edenproxyrwd.act< edenproxy::actions::init >();
+  t.eosproxyrwds.act< edenproxy::actions::init >();
   t.alice.act< token::actions::transfer >( "alice"_n,
-                                           "edenprxfunds"_n,
+                                           "eosproxyfund"_n,
                                            s2a( "512.0000 EOS" ),
                                            "donation" );
   t.full_signup();
@@ -340,9 +340,9 @@ TEST_CASE( "Cannot resign while a distributing" ) {
   t.fund_accounts();
   t.skip_to( "2023-01-01T07:00:00.000" );
 
-  t.edenproxyrwd.act< edenproxy::actions::init >();
+  t.eosproxyrwds.act< edenproxy::actions::init >();
   t.alice.act< token::actions::transfer >( "alice"_n,
-                                           "edenprxfunds"_n,
+                                           "eosproxyfund"_n,
                                            s2a( "512.0000 EOS" ),
                                            "donation" );
   t.full_signup();
@@ -365,9 +365,9 @@ TEST_CASE( "Use default recipient if no one is set" ) {
   t.fund_accounts();
   t.skip_to( "2023-01-01T07:00:00.000" );
 
-  t.edenproxyrwd.act< edenproxy::actions::init >();
+  t.eosproxyrwds.act< edenproxy::actions::init >();
   t.alice.act< token::actions::transfer >( "alice"_n,
-                                           "edenprxfunds"_n,
+                                           "eosproxyfund"_n,
                                            s2a( "512.0000 EOS" ),
                                            "donation" );
 
@@ -385,9 +385,9 @@ TEST_CASE( "Disable claim funds for an account" ) {
   t.fund_accounts();
   t.skip_to( "2023-01-01T07:00:00.000" );
 
-  t.edenproxyrwd.act< edenproxy::actions::init >();
+  t.eosproxyrwds.act< edenproxy::actions::init >();
   t.alice.act< token::actions::transfer >( "alice"_n,
-                                           "edenprxfunds"_n,
+                                           "eosproxyfund"_n,
                                            s2a( "512.0000 EOS" ),
                                            "donation" );
 
@@ -405,19 +405,19 @@ TEST_CASE( "Disable claim funds for an account" ) {
       t.bob.trace< edenproxy::actions::changercpt >( "alice"_n, ""_n, false ),
       "Missing required authority" );
 
-  expect( t.edenproxyrwd.trace< edenproxy::actions::changercpt >( "alice"_n,
+  expect( t.eosproxyrwds.trace< edenproxy::actions::changercpt >( "alice"_n,
                                                                   ""_n,
                                                                   false ),
           "Missing required authority" );
   expect(
       t.alice.trace< edenproxy::actions::changercpt >( "alice"_n, ""_n, true ),
       "Missing required authority" );
-  expect( t.edenproxyrwd.trace< edenproxy::actions::changercpt >( "alice"_n,
+  expect( t.eosproxyrwds.trace< edenproxy::actions::changercpt >( "alice"_n,
                                                                   "bob"_n,
                                                                   true ),
           "Admin can only ban" );
 
-  t.edenproxyrwd.act< edenproxy::actions::changercpt >( "alice"_n, ""_n, true );
+  t.eosproxyrwds.act< edenproxy::actions::changercpt >( "alice"_n, ""_n, true );
 
   expect( t.alice.trace< edenproxy::actions::changercpt >( "alice"_n,
                                                            "alice"_n,
@@ -438,9 +438,9 @@ TEST_CASE( "Skip distribution if there are no accounts" ) {
   t.fund_accounts();
   t.skip_to( "2023-01-01T07:00:00.000" );
 
-  t.edenproxyrwd.act< edenproxy::actions::init >();
+  t.eosproxyrwds.act< edenproxy::actions::init >();
   t.alice.act< token::actions::transfer >( "alice"_n,
-                                           "edenprxfunds"_n,
+                                           "eosproxyfund"_n,
                                            s2a( "512.0000 EOS" ),
                                            "donation" );
 

--- a/src/config/sdk.ts
+++ b/src/config/sdk.ts
@@ -18,7 +18,7 @@ export const edenSmartProxyContract =
 export const myVoteEOSDaoContract =
   process.env.NEXT_PUBLIC_MYVOTEEOSDAO_CONTRACT || 'myvoteeosdao'
 
-export const edenSmartProxyRewardContract = 'edenproxyrwd'
+export const edenSmartProxyRewardContract = 'eosproxyrwds'
 
 export const producersInfoApiUrl =
   process.env.NEXT_PUBLIC_PRODUCERS_INFO_API_URL ||

--- a/src/config/wallet/index.ts
+++ b/src/config/wallet/index.ts
@@ -17,6 +17,6 @@ const network: any = {
   ]
 }
 const authenticators = [new Anchor([network], { appName, verifyProofs: true })]
-const rewardAccount = 'edenproxyrwd'
+const rewardAccount = 'eosproxyrwds'
 
 export default { rpcEndpoint, authenticators, appName, network, rewardAccount }

--- a/src/pages/delegator/DelegatorActions.tsx
+++ b/src/pages/delegator/DelegatorActions.tsx
@@ -320,7 +320,7 @@ const DelegatorAction: React.FC<DelegateBody> = ({
             <TextField
               id='recipient-basic'
               label={t('account')}
-              placeholder='edenprxfunds'
+              placeholder='eosproxyfund'
               variant='outlined'
               size='small'
               value={recipient}


### PR DESCRIPTION
### Update Names

### What does this PR do?

- Update contract names from using the `eden` prefix to `eos` prefix